### PR TITLE
supports multiple file uploads.

### DIFF
--- a/assets/lib/file_system.rb
+++ b/assets/lib/file_system.rb
@@ -1,5 +1,5 @@
 class FileSystem
   def get(path)
-    File.new(path)
+    Dir.glob(path).map { |f| File.new(f) }
   end
 end

--- a/spec/fakes.rb
+++ b/spec/fakes.rb
@@ -51,7 +51,7 @@ end
 
 class FakeFS
   def get(path)
-    FakeFile.new(path)
+    [FakeFile.new(path)]
   end
 end
 

--- a/spec/file_system_spec.rb
+++ b/spec/file_system_spec.rb
@@ -1,0 +1,21 @@
+require_relative '../assets/lib/file_system'
+
+describe 'FileSystem' do
+
+  it 'creates files for specified paths' do
+    variant1 = 'app-mips64-release.apk'
+    variant2 = 'app-mips-release.apk'
+    file1 = double('File')
+    file2 = double('File')
+
+    allow(Dir).to receive(:glob).and_return([variant1, variant2])
+    allow(File).to receive(:new).with(variant1).and_return(file1)
+    allow(File).to receive(:new).with(variant2).and_return(file2)
+
+    variant_apks = FileSystem.new.get('*.apk')
+
+    expect(variant_apks.size).to be(2)
+    expect(variant_apks.first).to be(file1)
+    expect(variant_apks.last).to be(file2)
+  end
+end

--- a/spec/in_spec.rb
+++ b/spec/in_spec.rb
@@ -40,7 +40,8 @@ describe 'out' do
     action = Out.new(args, stdin, stdout, rest_client, fakefs)
     action.run
 
-    response = JSON.parse(stdout.read)
+    response = JSON.parse(stdout.read)[0]
+
     expect(response["version"]["ref"]).to eq("9000")
   end
 
@@ -55,8 +56,7 @@ describe 'out' do
     action = Out.new(args, stdin, stdout, rest_client, fakefs)
     action.run
 
-    response = JSON.parse(stdout.read)
-
+    response = JSON.parse(stdout.read)[0]
     expect(response["metadata"][0]["name"]).to eq("Version Code")
     expect(response["metadata"][0]["value"]).to eq("9000")
 


### PR DESCRIPTION
I recently decided to [split my android app apk](https://developer.android.com/studio/build/configure-apk-splits.html) to reduce the size of my artifacts. Unfortunately I am unable to push the variants to hockey-app because this resource does not support this functionality. 

Here is a pr to enable that. Please do give me feedback and or let me know if this something worth doing.  Thanks.