### PR TITLE
supports apk splits.

### DIFF
--- a/assets/lib/file_system.rb
+++ b/assets/lib/file_system.rb
@@ -1,5 +1,5 @@
 class FileSystem
   def get(path)
-    File.new(path)
+    Dir.glob(path).map { |f| File.new(f) }
   end
 end

--- a/assets/lib/out.rb
+++ b/assets/lib/out.rb
@@ -11,35 +11,37 @@ class Out
 
   def run
     input = @stdin.read
-    json = JSON.parse(input)
+    json_args = JSON.parse(input)
+    path = json_args['params']['path']
+    responses = @file_system.get("#{@args[0]}/#{path}").map do |apk|
+      upload(apk, json_args)
+    end
+    #use the first response for version output
+    output = parse_response(responses.first)
+    @stdout.write(JSON.generate(output))
+  end
 
-    app_id = json["source"]["app_id"]
-    token = json["source"]["token"]
-    path = json["params"]["path"]
-    downloadable = json["params"]["downloadable"]
+  private
 
-    response = @rest_client.post("https://rink.hockeyapp.net/api/2/apps/#{app_id}/app_versions/upload",
-      { :ipa => @file_system.get("#{@args[0]}/#{path}"), :status => downloadable ? 2 : 1 },
-      { "X-HockeyAppToken" => token })
-
-    version = JSON.parse(response)
-
-    output = {
-      :version => {
-        :ref => version["id"].to_s
-      },
-      :metadata => [
-        {
-          :name => "Version Code",
-          :value => version["version"]
-        },
-        {
-          :name => "Version Page",
-          :value => version["config_url"]
-        }
+  def parse_response(respose)
+    version = JSON.parse(respose)
+    {
+      version: { ref: version['id'].to_s },
+      metadata: [
+        { name: 'Version Code', value: version['version'] },
+        { name: 'Version Page', value: version['config_url'] }
       ]
     }
+  end
 
-    @stdout.write(JSON.generate(output))
+  def upload(apk, json)
+    app_id = json['source']['app_id']
+    token = json['source']['token']
+    downloadable = json['params']['downloadable']
+    @rest_client.post(
+      "https://rink.hockeyapp.net/api/2/apps/#{app_id}/app_versions/upload",
+      { ipa: apk, status: downloadable ? 2 : 1 },
+      'X-HockeyAppToken' => token
+    )
   end
 end

--- a/spec/fakes.rb
+++ b/spec/fakes.rb
@@ -51,7 +51,7 @@ end
 
 class FakeFS
   def get(path)
-    FakeFile.new(path)
+    [FakeFile.new(path)]
   end
 end
 

--- a/spec/file_system_spec.rb
+++ b/spec/file_system_spec.rb
@@ -1,0 +1,21 @@
+require_relative '../assets/lib/file_system'
+
+describe 'FileSystem' do
+
+  it 'creates files for specified paths' do
+    variant1 = 'app-mips64-release.apk'
+    variant2 = 'app-mips-release.apk'
+    file1 = double('File')
+    file2 = double('File')
+
+    allow(Dir).to receive(:glob).and_return([variant1, variant2])
+    allow(File).to receive(:new).with(variant1).and_return(file1)
+    allow(File).to receive(:new).with(variant2).and_return(file2)
+
+    variant_apks = FileSystem.new.get('*.apk')
+
+    expect(variant_apks.size).to be(2)
+    expect(variant_apks.first).to be(file1)
+    expect(variant_apks.last).to be(file2)
+  end
+end

--- a/spec/in_spec.rb
+++ b/spec/in_spec.rb
@@ -41,6 +41,7 @@ describe 'out' do
     action.run
 
     response = JSON.parse(stdout.read)
+
     expect(response["version"]["ref"]).to eq("9000")
   end
 
@@ -56,7 +57,6 @@ describe 'out' do
     action.run
 
     response = JSON.parse(stdout.read)
-
     expect(response["metadata"][0]["name"]).to eq("Version Code")
     expect(response["metadata"][0]["value"]).to eq("9000")
 


### PR DESCRIPTION
I recently decided to split my android app apk to reduce the size of my artifacts. Unfortunately I am unable to push the variants to hockey-app because this resource does not support this functionality.

Here is a pr to enable that. Please do give me feedback and or let me know if this something worth doing. Thanks.